### PR TITLE
Fix sample codes on the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ itesttool is Web API end-to-end test tool in RSpec.
 ```ruby
 describe 'send GET request' do
   _given {
-    headers 'referer' => 'http://local.example.com',
+    headers 'referer' => 'http://local.example.com'
   }
   _when { get 'http://localhost:4567/index', as_json }
   _then {

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ require 'itesttool'
 ```ruby
 describe 'send GET request' do
   _given {
-    headers 'referer' => 'http://local.example.com',
+    headers 'referer' => 'http://local.example.com'
   }
   _when { get 'http://localhost:4567/index' }
   _then {


### PR DESCRIPTION
Removed two comma at the end of the sample codes, cause they didn't work.
